### PR TITLE
Fix bug where the last microLabel would not be created properly

### DIFF
--- a/src/app/Model/Emulator/parser.service.ts
+++ b/src/app/Model/Emulator/parser.service.ts
@@ -691,6 +691,8 @@ export class ParserService {
       block.length = block.length + 1;
     }
 
+    blocks.push(block);
+
 
     // assure that "if labels" are 256 bit apart
     for (let line of tokens) {


### PR DESCRIPTION
Hotfix for a bug where the last microcode label was not created correctly and you would get an error when trying to jump to that label.